### PR TITLE
Fixed crashes

### DIFF
--- a/WifiProfiles/Program.cs
+++ b/WifiProfiles/Program.cs
@@ -22,7 +22,8 @@ namespace WifiProfiles
             if (sawBadWifi)
             {
                 Console.WriteLine("\r\nDelete WiFi profiles that are OPEN *and* AUTO connect? [y/n]");
-                if (args[0].ToUpperInvariant() == "/DELETEAUTOOPEN" || Console.ReadLine().Trim().ToUpperInvariant()[0] == 'Y')
+                if (args.Length > 0 && args[0].ToUpperInvariant() == "/DELETEAUTOOPEN" || 
+                    Console.ReadLine().Trim().ToUpperInvariant().StartsWith("Y"))
                 {
                     Console.WriteLine("in here");
                     foreach (var a in profiles.Where(a => NetShWrapper.IsOpenAndAutoWifiProfile(a)))


### PR DESCRIPTION
Do not crash when there are open hotspots and there are no parameters, or the user hits enter
